### PR TITLE
Remove script to enforce HTTPS. This can be handled by cloudflare.

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,12 +6,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="canonical" href="https://myvotematters.today"/>
         <link rel="stylesheet" type="text/css" href="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.2/css/bootstrap.min.css" media="screen">
-        <script type="text/javascript">
-            var host = "myvotematters.today";
-            if ((host == window.location.host) && (window.location.protocol != "https:")) {
-                window.location.protocol = "https";
-            }
-        </script>
         <script src="https://use.typekit.net/gay2ucd.js"></script>
         <script>try{Typekit.load({ async: true });}catch(e){}</script>
         <link rel='stylesheet' type='text/css' href='https://fonts.googleapis.com/css?family=Montserrat'>


### PR DESCRIPTION
Here are the instructions to do this using CloudFlare page rule:

https://support.cloudflare.com/hc/en-us/articles/200170536-How-do-I-redirect-all-visitors-to-HTTPS-SSL-
