### PR TITLE
Make sure jQuery is never raced by Bootstrap.

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
         <link rel="stylesheet" type="text/css" href="https://ajax.aspnetcdn.com/ajax/bootstrap/3.3.2/css/bootstrap.min.css" media="screen">
         <link rel='stylesheet' type='text/css' href='https://fonts.googleapis.com/css?family=Montserrat:400,700'>
         <link rel="stylesheet" type="text/css" href="css/main.css?v=5" media="screen">
-        <script async type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
         <script async type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
         <script type="text/javascript" src="js/main.js?v=7"></script>
         <script async type="text/javascript" src="js/oauth.min.js" id="oauth"></script>


### PR DESCRIPTION
Another race that happens is that jQuery doesn't load in time for Bootstrap, which causes the carousel to fail load.
