### PR TITLE
Makes #74 less bad.

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
                                 <a class="fb-share-button">
                                     <img src="img/facebook.png">
                                 </a>
-                                <a class="download-button" download="my_vote_matters.png">
+                                <a class="download-button" rel="noreferrer" download="my_vote_matters.png">
                                     <img src="img/download.png">
                                 </a>
                                 <a class="cancel-button">

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
                                 <a class="fb-share-button">
                                     <img src="img/facebook.png">
                                 </a>
-                                <a class="download-button">
+                                <a class="download-button" download="my_vote_matters.png">
                                     <img src="img/download.png">
                                 </a>
                                 <a class="cancel-button">

--- a/js/main.js
+++ b/js/main.js
@@ -161,7 +161,6 @@
 
     $controls.on('click', '.download-button', function() {
       ga('send', 'event', 'share', 'click', 'download');
-      downloadImage(this);
     });
 
     $window.on('orientationchange', function() {
@@ -304,7 +303,7 @@
       $('#share-photo').removeClass('no-display');
 
       linkToShare = response.data.link;
-      console.log(linkToShare);
+      document.querySelector('.download-button').href = linkToShare;
     }).catch(function(e){
       ga('send', 'event', 'share', 'error', 'imgur');
       onShareError('imgur', e);
@@ -395,12 +394,6 @@
         onShareError('facebook', response.error_message);
       }
     });
-  }
-
-  function downloadImage(link) {
-    var file = canvas.toDataURL("image/png").replace("image/png", "image/octet-stream");  // here is the most important part because if you dont replace you will get a DOM 18 exception.
-    link.href=file;
-    link.download = "my_vote_matters.png";
   }
 
   function dataURItoBlob(dataURI) {


### PR DESCRIPTION
In browsers that don't support the `download` attribute, we now just go to imgur where the image is. It's still a sad world, since there's literally [no way](https://github.com/eligrey/FileSaver.js/#ios) to make Safari or Chrome on iOS download images.