### PR TITLE
Make no-camera/iOS text always centered.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -243,7 +243,7 @@ ul.timeline li:active .details {
     padding: 1.5vh;
     align-items: center;
     box-sizing: border-box;
-    font-size: 2.8vh;
+    font-size: 1.7em;
 }
 
 #canvas {


### PR DESCRIPTION
There's a bug in Safari where with `vh` units. Let's just use `em`.